### PR TITLE
Improve subtitle support and re-factor colours

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,21 @@
 4. Create `/wvd/` folder and place .wvd file in folder (or specify the path to your existing *.wvd as below)
 5. Install necessary packages: `pip install -r requirements.txt`
 6. Config: 
-      -specify your Downloads path in the config.yaml (optional)
+      -specify your Downloads path in the `config.yaml` (optional)
 
-      -specify your path to *.wvd file in the config.yaml (mandatory)
+      -specify your path to *.wvd file in the `config.yaml` (mandatory)
 
-      Sample config.yaml file to confirm format
-
+      Sample `config.yaml` file to confirm the format:
+      ```yaml  
       downloads_path: "C:/Downloads/"
-   
       wvd_device_path: "C:/Downloads/Ozivine/wvd/l3.wvd"
-   
       cookies_path: "C:/Downloads/Ozivine/cookies/cookies.txt"
-
       credentials:
         10play: username:password       
         sbs: username:password
-
       tvnz:
         local_storage: "D:/Downloads/CDM/local_storage.json"    
-
+      ```
 
 > [!TIP]
 > Clone the main branch to always stay up to date:
@@ -168,6 +164,7 @@ It is recommneded to have a separate user account for this script and not share 
 
 To extract your local storage details, in your browser press F12 to go to Dev Tools, go to the Console tab, paste in the below and hit enter
 
+```javascript
 Object.assign(document.createElement('a'), {
   href: URL.createObjectURL(new Blob([JSON.stringify({
     accessToken: localStorage.accessToken,
@@ -176,6 +173,7 @@ Object.assign(document.createElement('a'), {
   }, null, 2)])),
   download: 'local_storage.json'
 }).click();
+```
 
 That will save a file named "local_storage.json" to your browser downloads folder.
 

--- a/helpers/colors.py
+++ b/helpers/colors.py
@@ -1,0 +1,24 @@
+"""
+Ozivine shared ANSI colour codes.
+
+Import and use as:
+    from helpers.colors import bcolors
+    print(f"{bcolors.OKGREEN}All good{bcolors.ENDC}")
+"""
+
+
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+    LIGHTBLUE = "\033[94m"
+    RED = "\033[91m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    ORANGE = "\033[38;5;208m"

--- a/helpers/subtitles.py
+++ b/helpers/subtitles.py
@@ -1,0 +1,110 @@
+"""
+Ozivine shared subtitle helpers.
+
+Some streaming services expose subtitles as separate sidecar files (WebVTT)
+rather than embedding them in the HLS/DASH stream. Each service module parses
+its own playback response into a common list-of-dicts:
+
+    [{"url": str, "lang": str, "name": str, "default": bool, "forced": bool}, ...]
+
+and then calls embed_subtitles() to convert them to SRT via ffmpeg and mux them
+into the MKV that N_m3u8DL-RE produced.
+
+Requires ffmpeg and mkvmerge on PATH (both are project-level requirements).
+"""
+
+import os
+import re
+import subprocess
+
+from helpers.colors import bcolors
+
+
+def sanitize_filename(name):
+    """Replace characters N_m3u8DL-RE strips from output filenames (cross-platform
+    invalid chars, e.g. "?" -> "_"), so the on-disk name is predictable and the
+    subtitle mux step can find the file."""
+    return re.sub(r'[\\/:*?"<>|]', "_", name)
+
+
+def describe(subtitles):
+    """Short comma-separated language list for display, e.g. "en, ar"."""
+    return ", ".join(s.get("lang", "und") for s in subtitles)
+
+
+def _fetch_and_convert_to_srt(url, srt_path):
+    """Use ffmpeg to fetch a WebVTT URL and write it as SRT in one step.
+    No intermediate file is created. Raises subprocess.CalledProcessError on failure."""
+    subprocess.run(
+        ["ffmpeg", "-y", "-loglevel", "error", "-i", url, srt_path],
+        check=True,
+    )
+
+
+def embed_subtitles(downloads_path, base_name, subtitles):
+    """Convert each subtitle track to SRT via ffmpeg (fetching directly from its
+    URL), then mux all tracks into {downloads_path}/{base_name}.mkv in place using
+    a temp file and atomic replace.
+
+    Each subtitle dict needs at least "url" and "lang"; "name", "default", and
+    "forced" are optional and used to set the MKV track metadata.
+
+    Returns True on success, False otherwise.
+    """
+    video_path = os.path.join(downloads_path, f"{base_name}.mkv")
+    if not os.path.exists(video_path):
+        print(f"{bcolors.WARNING}Video file not found, skipping subtitle mux: {video_path}{bcolors.ENDC}")
+        return False
+
+    multiple = len(subtitles) > 1
+    prepared = []
+    for index, sub in enumerate(subtitles):
+        lang = sub.get("lang", "und")
+        suffix = lang if not multiple else f"{lang}.{index}"
+        srt_path = os.path.join(downloads_path, f"{base_name}.{suffix}.srt")
+        try:
+            _fetch_and_convert_to_srt(sub["url"], srt_path)
+        except subprocess.CalledProcessError as e:
+            print(f"{bcolors.WARNING}Failed to convert {lang} subtitle to SRT: {e}{bcolors.ENDC}")
+            continue
+        prepared.append({
+            "path": srt_path,
+            "lang": lang,
+            "name": sub.get("name", ""),
+            "default": bool(sub.get("default")),
+            "forced": bool(sub.get("forced")),
+        })
+        print(f"{bcolors.OKGREEN}✅ Downloaded and converted {lang} subtitle{bcolors.ENDC}")
+
+    if not prepared:
+        print(f"{bcolors.WARNING}No subtitle files prepared; nothing to mux.{bcolors.ENDC}")
+        return False
+
+    tmp_path = os.path.join(downloads_path, f"{base_name}.tmp.mkv")
+    command = ["mkvmerge", "-o", tmp_path, video_path]
+    for sub in prepared:
+        command += ["--language", f"0:{sub['lang']}"]
+        if sub["name"]:
+            command += ["--track-name", f"0:{sub['name']}"]
+        command += [
+            "--default-track-flag", f"0:{'yes' if sub['default'] else 'no'}",
+            "--forced-display-flag", f"0:{'yes' if sub['forced'] else 'no'}",
+            sub["path"],
+        ]
+
+    result = subprocess.run(command)
+    # mkvmerge exit codes: 0 = success, 1 = success with warnings, 2 = error.
+    if result.returncode in (0, 1):
+        os.replace(tmp_path, video_path)
+        for sub in prepared:
+            try:
+                os.remove(sub["path"])
+            except OSError:
+                pass
+        print(f"{bcolors.OKGREEN}✅ Embedded {len(prepared)} subtitle track(s) into {base_name}.mkv{bcolors.ENDC}")
+        return True
+
+    print(f"{bcolors.FAIL}mkvmerge failed (exit {result.returncode}); leaving .srt files in place.{bcolors.ENDC}")
+    if os.path.exists(tmp_path):
+        os.remove(tmp_path)
+    return False

--- a/ozivine.py
+++ b/ozivine.py
@@ -6,6 +6,8 @@ from rich.padding import Padding
 from rich.text import Text
 from datetime import datetime
 
+from helpers.colors import bcolors
+
 #   Ozivine: Downloader for Australian & New Zealand FTA services
 #   Author: billybanana
 #   Quality: up to 1080p
@@ -20,6 +22,7 @@ from datetime import datetime
 console = Console()
 __version__ = "2.1"  # Replace with the actual version
 
+
 def print_ascii_art(version=None):
     ascii_art = Text(
         r"          _       _            " + "\n"
@@ -28,7 +31,7 @@ def print_ascii_art(version=None):
         r"| (_) / /| |\ V /| | | | |  __/ " + "\n"
         r" \___/___|_| \_/ |_|_| |_|\___| " + "\n"
         r"                               ",
-        
+
     )
 
     version_info = Text(f"Version {__version__} Copyright © {datetime.now().year} billybanana", style="none")
@@ -41,19 +44,12 @@ def print_ascii_art(version=None):
 
     if version:
         return
-    
-# Define color formatting
-class bcolors:
-    LIGHTBLUE = '\033[94m'
-    RED = '\033[91m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    ENDC = '\033[0m'
-    ORANGE = '\033[38;5;208m'
+
 
 def load_config():
     with open('config.yaml', 'r') as file:
         return yaml.safe_load(file)
+
 
 def main():
     print_ascii_art(version=__version__)  # Display the ASCII art and version info
@@ -93,7 +89,7 @@ def main():
     elif video_url.startswith(("https://10play.com.au/", "https://10.com.au/")):
         service_module = "services.10play.10play"
         print(f"{bcolors.LIGHTBLUE}Ozivine..........initiating 10{bcolors.ENDC}")
-        args = (video_url, downloads_path, credentials.get("10play")) 
+        args = (video_url, downloads_path, credentials.get("10play"))
     elif video_url.startswith("https://www.tvnz.co.nz/"):
         service_module = "services.tvnz.tvnz"
         print(f"{bcolors.LIGHTBLUE}Ozivine..........initiating TVNZ{bcolors.ENDC}")
@@ -102,11 +98,11 @@ def main():
             print(f"{bcolors.RED}Missing config value: tvnz.local_storage{bcolors.ENDC}")
             sys.exit(1)
 
-        args = (video_url, downloads_path, wvd_device_path, tvnz_local_storage) 
+        args = (video_url, downloads_path, wvd_device_path, tvnz_local_storage)
     elif video_url.startswith("https://www.threenow.co.nz"):
         service_module = "services.threenow.threenow"
         print(f"{bcolors.LIGHTBLUE}Ozivine..........initiating ThreeNow{bcolors.ENDC}")
-        args = (video_url, downloads_path, wvd_device_path)                      
+        args = (video_url, downloads_path, wvd_device_path)
     else:
         print(f"{bcolors.RED}Unsupported URL. Please enter a valid video URL from 9Now, 7Plus, 10Play, SBS, ABC iView, ThreeNow or TVNZ.{bcolors.ENDC}")
         sys.exit(1)
@@ -116,6 +112,7 @@ def main():
         service.main(*args)
     except Exception as e:
         print(f"{bcolors.RED}Error importing or running the service module: {e}{bcolors.ENDC}")
+
 
 if __name__ == "__main__":
     main()

--- a/services/10play/10play.py
+++ b/services/10play/10play.py
@@ -5,7 +5,7 @@ import subprocess
 import re
 import os
 import random
-from urllib.parse import urljoin  
+from urllib.parse import urljoin
 
 #   Ozivine: 10Play Video Downloader
 #   Author: billybanana
@@ -19,20 +19,9 @@ from urllib.parse import urljoin
 #   2. Print Download Information: Outputs the M3U8 URL required for downloading the video content.
 #   3. Note: this script functions for AES_128 encrypted video files only.
 
-# Formatting for output
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
-    LIGHTBLUE = '\033[94m'
-    YELLOW = '\033[93m'
-    ORANGE = '\033[93m'
+from helpers.colors import bcolors
+from helpers.subtitles import embed_subtitles
+
 
 ### Helpers ###
 
@@ -43,17 +32,6 @@ def fetch_text(url, timeout=15):
     r.raise_for_status()
     return r.text
 
-def get_first_segment_url(media_m3u8_text: str, media_m3u8_url: str) -> str | None:
-    """
-    Return absolute URL of the first segment in a media playlist.
-    """
-    for line in media_m3u8_text.splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        # First non-tag line is a segment URI
-        return urljoin(media_m3u8_url, line)
-    return None
 
 def _extract_segment_urls(media_m3u8_text: str, media_m3u8_url: str):
     segs = []
@@ -63,6 +41,7 @@ def _extract_segment_urls(media_m3u8_text: str, media_m3u8_url: str):
             continue
         segs.append(urljoin(media_m3u8_url, s))
     return segs
+
 
 def _tiny_get_ok(url: str, timeout=8) -> bool:
     try:
@@ -77,6 +56,7 @@ def _tiny_get_ok(url: str, timeout=8) -> bool:
         return r.status_code in (200, 206)
     except Exception:
         return False
+
 
 def probe_segment_ok(m3u8_source: str, timeout=10) -> bool:
     """
@@ -111,6 +91,7 @@ def probe_segment_ok(m3u8_source: str, timeout=10) -> bool:
     except Exception:
         return False
 
+
 def parse_master_variants(master_text: str, master_url: str):
     """
     Parse a master playlist; return list of dicts with height and absolute URL.
@@ -134,6 +115,7 @@ def parse_master_variants(master_text: str, master_url: str):
     variants.sort(key=lambda v: v["height"], reverse=True)
     return variants
 
+
 def pick_best_variant(master_url: str) -> tuple[str, int] | tuple[None, None]:
     """
     Return (variant_url, height) for the best available rendition.
@@ -148,6 +130,7 @@ def pick_best_variant(master_url: str) -> tuple[str, int] | tuple[None, None]:
     except Exception:
         return None, None
 
+
 def replace_resolution_tag(save_name: str, new_height: int) -> str:
     """
     Replace .1080p. (or any .####p.) in the save-name with the detected height.
@@ -159,7 +142,8 @@ def replace_resolution_tag(save_name: str, new_height: int) -> str:
         return re.sub(r"\.(\d{3,4})p\.", f".{new_height}p.", save_name, count=1)
     # try to insert before ".10Play." or at end
     return re.sub(r"(\.10Play\.)", f".{new_height}p.\\1", save_name, count=1) \
-           if ".10Play." in save_name else f"{save_name}.{new_height}p"
+        if ".10Play." in save_name else f"{save_name}.{new_height}p"
+
 
 ### End of Helpers ###
 
@@ -172,6 +156,7 @@ headers = {
     'Origin': 'https://10play.com.au',
     'Referer': 'https://10play.com.au/'
 }
+
 
 # Function to get bearer token
 def get_bearer_token(username, password):
@@ -211,7 +196,7 @@ def extract_video_details(video_id, token, episode_url):
     # include tp-acceptfeature + bearer
     auth_headers = _build_auth_headers(token)
 
-    # 1) Get the video doc 
+    # 1) Get the video doc
     response = requests.get(video_api_url, headers=auth_headers, timeout=20)
     if response.status_code != 200:
         print(f"{bcolors.FAIL}Failed to fetch video details ({response.status_code}){bcolors.ENDC}")
@@ -219,7 +204,7 @@ def extract_video_details(video_id, token, episode_url):
 
     video_data = response.json()
 
-    # 2) Playback endpoint 
+    # 2) Playback endpoint
     playback_url = f"https://10play.com.au/api/v1/videos/playback/{video_id}?platform=tizen"
     playback_response = requests.get(playback_url, headers=auth_headers, timeout=20)
     if playback_response.status_code != 200:
@@ -258,7 +243,7 @@ def extract_video_details(video_id, token, episode_url):
     return None, None
 
 
-# Function to retrieve stream manifest URL 
+# Function to retrieve stream manifest URL
 def get_stream_manifest(content_source_id, video_id, dai_auth_token, episode_url):
     """
     Google DAI streams endpoint.
@@ -274,10 +259,10 @@ def get_stream_manifest(content_source_id, video_id, dai_auth_token, episode_url
     form = {
         "cmsid": content_source_id,
         "vid": video_id,
-        "auth-token": dai_auth_token,                         # REQUIRED
-        "url": episode_url,                                   
-        "ua": ua,                                             
-        "correlator": str(random.randint(10**12, 10**16)),    
+        "auth-token": dai_auth_token,  # REQUIRED
+        "url": episode_url,
+        "ua": ua,
+        "correlator": str(random.randint(10 ** 12, 10 ** 16)),
     }
     stream_headers = {
         "User-Agent": ua,
@@ -298,7 +283,7 @@ def get_stream_manifest(content_source_id, video_id, dai_auth_token, episode_url
 
     # Sometimes DAI returns an m3u8 directly
     if "application/vnd.apple.mpegurl" in ctype or text.startswith("#EXTM3U"):
-        return response.url 
+        return response.url
 
         # Or JSON that includes stream URLs
     if "application/json" in ctype:
@@ -310,9 +295,9 @@ def get_stream_manifest(content_source_id, video_id, dai_auth_token, episode_url
 
         # Prefer direct manifest fields the DAI API returns
         direct = (
-            data.get("stream_manifest")
-            or data.get("manifest")
-            or data.get("url")
+                data.get("stream_manifest")
+                or data.get("manifest")
+                or data.get("url")
         )
         if isinstance(direct, str) and direct.startswith("http"):
             return direct
@@ -344,6 +329,7 @@ def download_and_select_variant(manifest_url):
     else:
         print(f"{bcolors.FAIL}Failed to download manifest: {response.status_code}{bcolors.ENDC}")
         return None
+
 
 # Function to modify the variant M3U8 content and save with proper filename
 def modify_and_save_m3u8(variant_url, downloads_path):
@@ -384,20 +370,45 @@ def format_file_name(video_data):
         episode = int(video_data['episode'])
         season_episode_tag = f"S{season:02d}E{episode:02d}"
         formatted_file_name = f"{show_name}.{season_episode_tag}.1080p.10Play.WEB-DL.AAC2.0.H.264"
-    
+
     return formatted_file_name
 
+
+# Function to collect the subtitle playlist URI from the master manifest.
+# The subtitle track is declared only in the master as an EXT-X-MEDIA SUBTITLES
+# entry with a URI pointing to a segmented WebVTT playlist. Higher-quality variant
+# playlists omit this declaration entirely. ffmpeg (via embed_subtitles) fetches
+# the playlist URL directly and concatenates all segments into an SRT.
+def collect_subtitles(master_url):
+    try:
+        text = fetch_text(master_url)
+    except Exception as e:
+        print(f"{bcolors.WARNING}Could not fetch master for subtitle URI: {e}{bcolors.ENDC}")
+        return None
+
+    for line in text.splitlines():
+        if 'EXT-X-MEDIA' not in line:
+            continue
+        if 'TYPE=SUBTITLES' not in line and 'TYPE=CLOSED-CAPTIONS' not in line:
+            continue
+        uri_m = re.search(r'URI="([^"]+)"', line)
+        if uri_m:
+            return uri_m.group(1)
+    return None
+
+
 # Function to format and display download command
-def display_download_command(m3u8_file_path, formatted_file_name, downloads_path, master_m3u8_url):
-    use_source = m3u8_file_path   # default to local file
+def display_download_command(m3u8_file_path, formatted_file_name, downloads_path,
+                             master_m3u8_url):
+    use_source = m3u8_file_path
     final_save_name = formatted_file_name
 
     print(f"{bcolors.LIGHTBLUE}FHD M3U8 File: {bcolors.ENDC}{m3u8_file_path}")
 
-    # Pre-flight probe: if it looks bad, pre-switch to master best
+    # Pre-flight probe: if segments look bad, fall back to best from master.
     preflight_failed = not probe_segment_ok(m3u8_file_path)
     if preflight_failed:
-        print(f"{bcolors.WARNING}First/middle/end segment probe failed — falling back to best available from master.{bcolors.ENDC}")
+        print(f"{bcolors.WARNING}Segment probe failed — falling back to best available from master.{bcolors.ENDC}")
         best_url, best_h = pick_best_variant(master_m3u8_url)
         if best_url:
             use_source = best_url
@@ -408,11 +419,19 @@ def display_download_command(m3u8_file_path, formatted_file_name, downloads_path
         else:
             print(f"{bcolors.FAIL}Could not pick a fallback variant from master.{bcolors.ENDC}")
 
-    # Build command
+    # The subtitle track is a segmented WebVTT playlist declared only on the master.
+    # ffmpeg (via embed_subtitles) fetches the playlist URL directly, concatenates
+    # all segments into an SRT, and mkvmerge embeds it — same pipeline as ABC/SBS.
+    subtitle_uri = collect_subtitles(master_m3u8_url)
+    if subtitle_uri:
+        print(f"{bcolors.OKCYAN}Subtitle playlist found{bcolors.ENDC}")
+    else:
+        print(f"{bcolors.WARNING}No subtitle playlist found in master.{bcolors.ENDC}")
+
     download_command = (
         f'N_m3u8DL-RE "{use_source}" '
         f'--ad-keyword redirector.googlevideo.com '
-        f'--select-video best --select-audio best --select-subtitle all '
+        f'--select-video best --select-audio best '
         f'-mt -M format=mkv --save-dir "{downloads_path}" --save-name "{final_save_name}"'
     )
     print(f"{bcolors.YELLOW}DOWNLOAD COMMAND:{bcolors.ENDC}")
@@ -420,10 +439,8 @@ def display_download_command(m3u8_file_path, formatted_file_name, downloads_path
 
     user_input = input("Do you wish to download? Y or N: ").strip().lower()
     if user_input == 'y':
-        # First attempt
         result = subprocess.run(download_command, shell=True)
         if result.returncode != 0 and not preflight_failed:
-            # Runtime fallback: if we *thought* the playlist was fine but the tool failed (404, etc.)
             print(f"{bcolors.WARNING}Downloader failed; attempting fallback from master...{bcolors.ENDC}")
             best_url, best_h = pick_best_variant(master_m3u8_url)
             if best_url:
@@ -431,14 +448,24 @@ def display_download_command(m3u8_file_path, formatted_file_name, downloads_path
                 fb_cmd = (
                     f'N_m3u8DL-RE "{best_url}" '
                     f'--ad-keyword redirector.googlevideo.com '
-                    f'--select-video best --select-audio best --select-subtitle all '
+                    f'--select-video best --select-audio best '
                     f'-mt -M format=mkv --save-dir "{downloads_path}" --save-name "{fallback_save}"'
                 )
                 print(f"{bcolors.YELLOW}FALLBACK DOWNLOAD COMMAND:{bcolors.ENDC}")
                 print(fb_cmd)
-                subprocess.run(fb_cmd, shell=True)
+                result = subprocess.run(fb_cmd, shell=True)
+                final_save_name = fallback_save
             else:
                 print(f"{bcolors.FAIL}Fallback failed: could not parse master playlist.{bcolors.ENDC}")
+
+        if result.returncode == 0 and subtitle_uri:
+            embed_subtitles(downloads_path, final_save_name, [{
+                "url": subtitle_uri,
+                "lang": "en",
+                "name": "English",
+                "default": True,
+                "forced": False,
+            }])
 
     # Always delete local .m3u8
     if os.path.exists(m3u8_file_path):
@@ -454,11 +481,12 @@ def extract_video_id(url):
     match = re.search(r'/([^/]+)/?$', url)
     return match.group(1) if match else None
 
+
 # Main logic
 def main(video_url, downloads_path, credentials):
     username, password = credentials.split(':')
     video_id = extract_video_id(video_url)
-    
+
     if not video_id:
         print(f"{bcolors.FAIL}Invalid URL. Please enter a valid 10Play video URL.{bcolors.ENDC}")
         return
@@ -470,14 +498,13 @@ def main(video_url, downloads_path, credentials):
         if manifest_url and video_data:
             variant_url = download_and_select_variant(manifest_url)
             if variant_url:
-                local_m3u8_file, original_variant_url = modify_and_save_m3u8(variant_url, downloads_path)
+                local_m3u8_file, variant_540_url = modify_and_save_m3u8(variant_url, downloads_path)
                 if local_m3u8_file:
-                    # Print the original 960x540 URL and the local path
                     print(f"{bcolors.LIGHTBLUE}MASTER M3U8 URL: {bcolors.ENDC}{manifest_url}")
-                    print(f"{bcolors.LIGHTBLUE}SD M3U8 URL: {bcolors.ENDC}{original_variant_url}")
-                    
+                    print(f"{bcolors.LIGHTBLUE}SD M3U8 URL: {bcolors.ENDC}{variant_540_url}")
                     formatted_file_name = format_file_name(video_data)
-                    display_download_command(local_m3u8_file, formatted_file_name, downloads_path, manifest_url)
+                    display_download_command(local_m3u8_file, formatted_file_name,
+                                             downloads_path, manifest_url)
                 else:
                     print(f"{bcolors.FAIL}Failed to modify and save the variant M3U8{bcolors.ENDC}")
             else:

--- a/services/7plus/7plus.py
+++ b/services/7plus/7plus.py
@@ -21,7 +21,7 @@ from requests.adapters import HTTPAdapter
 #   Geo-Locking: requires an Australian IP address
 #   Quality: up to 720p
 #   Key Features:
-#   1. Extract Video ID: Parses the 7Plus URL to extract the series name, season, and episode number, and then fetches the Brightcove video ID from the 9Now API.
+#   1. Extract Video ID: Parses the 7Plus URL to extract the episode ID and then fetches the stream info from the 7Plus videoservice API.
 #   2. Extract PSSH: Retrieves and parses the MPD file to extract the PSSH data necessary for Widevine decryption.
 #   3. Fetch Decryption Keys: Uses the PSSH and license URL to request and retrieve the Widevine decryption keys.
 #   4. Print Download Information: Outputs the MPD URL, license URL, PSSH, and decryption keys required for downloading and decrypting the video content.
@@ -31,6 +31,7 @@ from requests.adapters import HTTPAdapter
 # Set DEBUG_ALL=True to re-enable ALL print() calls across this module.
 # Leave it False to silence everything except explicit _PRINT(...) calls below.
 import builtins
+
 DEBUG_ALL = False
 
 # Keep a handle to the real print
@@ -42,23 +43,12 @@ if not DEBUG_ALL:
         return
 # =============================================================================
 
-# Formatting for output
-class bcolors:
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    LIGHTBLUE = '\033[94m'
-    RED = '\033[91m'
-    YELLOW = '\033[93m'
-    GREEN = '\033[92m'
-    ORANGE = '\033[38;5;208m'
+from helpers.colors import bcolors
 
 # URLs and Headers
 BASE_URL = "https://7plus.com.au"
 PLATFORM_VERSION = "1.0.106518"
+
 
 def _default_headers(referer_path="/", auth_token=None, conn_close=False):
     h = {
@@ -84,6 +74,7 @@ def _default_headers(referer_path="/", auth_token=None, conn_close=False):
         h["Authorization"] = f"Bearer {auth_token}"
     return h
 
+
 def _session_with_retries(total=3, backoff=0.5, pool_maxsize=20):
     s = requests.Session()
     retry = Retry(
@@ -100,6 +91,7 @@ def _session_with_retries(total=3, backoff=0.5, pool_maxsize=20):
     s.mount("https://", adapter)
     s.mount("http://", adapter)
     return s
+
 
 def get_authenticated_session(video_url, cookies_path):
     """
@@ -164,6 +156,7 @@ def get_authenticated_session(video_url, cookies_path):
 
     return session, auth_token
 
+
 def get_pssh(mpd_url):
     response = requests.get(mpd_url)
     if response.status_code != 200:
@@ -176,6 +169,7 @@ def get_pssh(mpd_url):
         return None
     return pssh_elements[0].text
 
+
 # Function to extract video details
 def extract_info(video_url, cookies_path, session=None, auth_token=None):
     # Ensure we have an authenticated session/token
@@ -184,7 +178,7 @@ def extract_info(video_url, cookies_path, session=None, auth_token=None):
 
     headers = _default_headers("/", auth_token)
 
-    # Playback endpoint + params 
+    # Playback endpoint + params
     media_url = 'https://videoservice.swm.digital/playback'
     path, episode_id = re.search(
         r'https?://(?:www\.)?7plus\.com\.au/(?P<path>[^?]+\?.*?\bepisode-id=(?P<id>[^&#]+))',
@@ -249,6 +243,7 @@ def extract_info(video_url, cookies_path, session=None, auth_token=None):
         print("No suitable source found for video")
         return None
 
+
 # Function to get decryption keys
 def get_keys(pssh, lic_url, wvd_device_path):
     try:
@@ -261,7 +256,7 @@ def get_keys(pssh, lic_url, wvd_device_path):
     cdm = Cdm.from_device(device)
     session_id = cdm.open()
     challenge = cdm.get_license_challenge(session_id, pssh)
-    
+
     headers = {
         'Content-Type': 'application/dash+xml',
         'Origin': 'https://7plus.com.au',
@@ -270,7 +265,7 @@ def get_keys(pssh, lic_url, wvd_device_path):
     }
 
     licence = requests.post(lic_url, headers=headers, data=challenge)
-    
+
     try:
         licence.raise_for_status()
     except requests.exceptions.HTTPError as e:
@@ -284,6 +279,7 @@ def get_keys(pssh, lic_url, wvd_device_path):
     cdm.close(session_id)
 
     return keys
+
 
 # Function to get the maximum video resolution from the MPD manifest
 def get_resolution_from_mpd(mpd_url):
@@ -302,6 +298,7 @@ def get_resolution_from_mpd(mpd_url):
     height = best_representation.attrib.get('height')
     return f"{height}p" if height else None
 
+
 # Function to get the maximum video resolution from the M3U8 manifest
 def get_resolution_from_m3u8(m3u8_url):
     response = requests.get(m3u8_url)
@@ -316,6 +313,7 @@ def get_resolution_from_m3u8(m3u8_url):
         return None
     best_resolution = max(resolutions, key=lambda r: int(r.split('x')[1]))
     return f"{best_resolution.split('x')[1]}p"
+
 
 # Function to format and display download command
 def get_download_command(info, show_title, season_episode_tag, downloads_path, wvd_device_path):
@@ -345,7 +343,7 @@ def get_download_command(info, show_title, season_episode_tag, downloads_path, w
             download_command = f"""N_m3u8DL-RE "{url}" --select-video best --select-audio best --select-subtitle all -mt -M format=mkv --save-dir "{downloads_path}" --save-name "{formatted_file_name}" """
             if keys:
                 download_command += " --key " + " --key ".join(keys)
-        
+
         # -- VISIBLE OUTPUT (encrypted MPD) -----------------------------------
         _PRINT(f"{bcolors.LIGHTBLUE}MPD URL: {bcolors.ENDC}{url}")
         _PRINT(f"{bcolors.RED}License URL: {bcolors.ENDC}{lic_url}")
@@ -355,7 +353,7 @@ def get_download_command(info, show_title, season_episode_tag, downloads_path, w
         _PRINT(f"{bcolors.YELLOW}DOWNLOAD COMMAND:{bcolors.ENDC}")
         _PRINT(download_command)
         # ---------------------------------------------------------------------
-        
+
         user_input = input("Do you wish to download? Y or N: ").strip().lower()
         if user_input == 'y':
             subprocess.run(download_command, shell=True)
@@ -369,22 +367,23 @@ def get_download_command(info, show_title, season_episode_tag, downloads_path, w
                 formatted_file_name += f".{season_episode_tag}"
             formatted_file_name += f".{resolution}.7PLUS.WEB-DL.AAC2.0.H.264"
             download_command = f"""N_m3u8DL-RE "{url}" --select-video best --select-audio best --select-subtitle all -mt -M format=mkv --save-dir "{downloads_path}" --save-name "{formatted_file_name}" """
-            
+
             # -- VISIBLE OUTPUT (unencrypted m3u8) -----------------------------
             _PRINT(f"{bcolors.LIGHTBLUE}M3U8 URL: {bcolors.ENDC}{url}")
             _PRINT(f"{bcolors.YELLOW}DOWNLOAD COMMAND: {bcolors.ENDC}")
             _PRINT(download_command)
             # ------------------------------------------------------------------
-            
+
             user_input = input("Do you wish to download? Y or N: ").strip().lower()
             if user_input == 'y':
                 subprocess.run(download_command, shell=True)
         else:
-            print(f"{bcolors.FAIL}Failed to retrieve necessary information for download{bcolors.ENDC}")       
+            print(f"{bcolors.FAIL}Failed to retrieve necessary information for download{bcolors.ENDC}")
 
-# Main logic
-def main(video_url, downloads_path, wvd_device_path, cookies_path): 
+        # Main logic
 
+
+def main(video_url, downloads_path, wvd_device_path, cookies_path):
     # 1) Probe playback (unchanged) — add progress around it
     print(f"{bcolors.OKBLUE}[STEP] Calling extract_info (videoservice)…{bcolors.ENDC}")
     info = extract_info(video_url, cookies_path)
@@ -417,7 +416,7 @@ def main(video_url, downloads_path, wvd_device_path, cookies_path):
         return
     session.cookies = cookies
 
-    # Browser-y headers 
+    # Browser-y headers
     headers = {
         "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
                       "AppleWebKit/537.36 (KHTML, like Gecko) "
@@ -534,4 +533,3 @@ def main(video_url, downloads_path, wvd_device_path, cookies_path):
     # 10) Kick off download command (unchanged)
     print(f"{bcolors.OKBLUE}[STEP] Building download command…{bcolors.ENDC}")
     get_download_command(info, show_title, season_episode_tag, downloads_path, wvd_device_path)
-    

--- a/services/9now/9now.py
+++ b/services/9now/9now.py
@@ -10,6 +10,9 @@ import base64
 import binascii
 import datetime
 
+from helpers.colors import bcolors
+from helpers.subtitles import sanitize_filename, describe, embed_subtitles
+
 #   9Now Video Downloader
 #   Author: billybanana
 #   Usage: enter the series/season/episode URL to retrieve the MPD, Licence, PSSH and Decryption keys.
@@ -37,23 +40,6 @@ BRIGHTCOVE_HEADERS = {
 }
 BRIGHTCOVE_API = lambda video_id: f"https://edge.api.brightcove.com/playback/v1/accounts/{BRIGHTCOVE_ACCOUNT}/videos/{video_id}"
 
-# ANSI escape codes for colors
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
-    LIGHTBLUE = '\033[94m'
-    RED = '\033[91m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    ORANGE = '\033[38;5;208m'
-
 
 def _season_tag_from_slug(slug: str) -> str:
     """
@@ -74,12 +60,14 @@ def _season_tag_from_slug(slug: str) -> str:
         return f"S{int(m2.group(1)):02d}"
     return "S00"
 
+
 def _get_season_page(series_name: str, season_slug: str):
     url = f"https://tv-api.9now.com.au/v2/pages/tv-series/{series_name}/seasons/{season_slug}?device=web"
     r = requests.get(url, timeout=20)
     if r.status_code == 200:
         return r.json()
     return None
+
 
 def _extract_clips_from_page(page_json):
     """
@@ -95,6 +83,7 @@ def _extract_clips_from_page(page_json):
                 out.append(it)
     return out
 
+
 def _clip_sort_key(c):
     dt = c.get('availability') or c.get('updatedAt') or ""
     for f in ('%Y-%m-%dT%H:%M:%S.%fZ', '%Y-%m-%dT%H:%M:%SZ'):
@@ -104,11 +93,12 @@ def _clip_sort_key(c):
             pass
     return datetime.datetime.min
 
+
 def get_video_id_from_url(video_url):
     # Episodes (existing patterns)
     season_episode_match = re.search(r'9now\.com\.au/([^/]+)/season-(\d+)/episode-(\d+)', video_url)
-    year_episode_match   = re.search(r'9now\.com\.au/([^/]+)/(\d{4})/episode-(\d+)', video_url)
-    special_episode_match= re.search(r'9now\.com\.au/([^/]+)/special/episode-(\d+)', video_url)
+    year_episode_match = re.search(r'9now\.com\.au/([^/]+)/(\d{4})/episode-(\d+)', video_url)
+    special_episode_match = re.search(r'9now\.com\.au/([^/]+)/special/episode-(\d+)', video_url)
 
     # NEW: Clips
     # e.g. https://www.9now.com.au/premier-league-epl-football/season-20252026/clip-cmeop4x67000m0hmmc1822v1i
@@ -150,8 +140,8 @@ def get_video_id_from_url(video_url):
 
     elif clip_match:
         series_name = clip_match.group(1)
-        season_slug = clip_match.group('season')          # e.g. season-20252026
-        clip_slug   = clip_match.group('clip')            # e.g. clip-cmeop4x...
+        season_slug = clip_match.group('season')  # e.g. season-20252026
+        clip_slug = clip_match.group('clip')  # e.g. clip-cmeop4x...
 
         # Fetch the season landing page, find the clip by its link path
         season_page = _get_season_page(series_name, season_slug)
@@ -177,7 +167,6 @@ def get_video_id_from_url(video_url):
         video_id = (clip_obj.get('video') or {}).get('brightcoveId')
         if not video_id:
             raise ValueError("Brightcove ID missing for the matched clip.")
-
 
         # Clean up the display name for filesystem use
         raw_title = clip_obj.get('displayName') or clip_obj.get('name') or ''
@@ -214,6 +203,7 @@ def get_pssh(url_mpd):
         print(f"Error fetching PSSH: {e}")
     return None
 
+
 # Function to get maximum video height from MPD URL
 def get_max_height_mpd(url_mpd):
     try:
@@ -229,6 +219,7 @@ def get_max_height_mpd(url_mpd):
     except Exception as e:
         print(f"Error fetching max height from MPD: {e}")
     return 0
+
 
 # Function to get maximum video height from m3u8 URL
 def get_max_height_m3u8(url_m3u8):
@@ -247,6 +238,7 @@ def get_max_height_m3u8(url_m3u8):
         print(f"Error fetching max height from m3u8: {e}")
     return 0
 
+
 # Function to get keys using PSSH and license URL
 def get_keys(pssh, lic_url, wvd_device_path):
     try:
@@ -260,7 +252,7 @@ def get_keys(pssh, lic_url, wvd_device_path):
         cdm = Cdm.from_device(device)
         session_id = cdm.open()
         challenge = cdm.get_license_challenge(session_id, pssh)
-        
+
         # Headers for the license request
         headers = {
             'Content-Type': 'application/octet-stream',
@@ -271,7 +263,7 @@ def get_keys(pssh, lic_url, wvd_device_path):
 
         # Make the license request
         licence = requests.post(lic_url, headers=headers, data=challenge)
-        
+
         # Check for errors in the response
         try:
             licence.raise_for_status()
@@ -290,6 +282,32 @@ def get_keys(pssh, lic_url, wvd_device_path):
         print(f"Error fetching keys: {e}")
     return []
 
+
+# Function to collect subtitle tracks from a Brightcove playback API response.
+# Brightcove returns subtitles as a "text_tracks" list alongside "sources".
+# Each entry has: src (URL), srclang (BCP-47), label, kind, mime_type, default.
+# We only want WebVTT captions/subtitles tracks (not chapters or metadata).
+def collect_subtitles(response):
+    out = []
+    for t in response.get("text_tracks", []):
+        # Brightcove uses "text/webvtt" in practice; also accept "text/vtt".
+        if t.get("mime_type", "").lower() not in ("text/vtt", "text/webvtt"):
+            continue
+        if t.get("kind", "").lower() not in ("captions", "subtitles"):
+            continue
+        # Skip thumbnail sprite tracks (no srclang, labelled "thumbnails").
+        if not t.get("srclang"):
+            continue
+        out.append({
+            "url": t["src"],
+            "lang": t.get("srclang", "und"),
+            "name": t.get("label", ""),
+            "default": bool(t.get("default")),
+            "forced": False,
+        })
+    return out
+
+
 # Function to process and print the download command
 def get_download_command(video_url, downloads_path, wvd_device_path):
     video_info = get_video_id_from_url(video_url)
@@ -303,9 +321,12 @@ def get_download_command(video_url, downloads_path, wvd_device_path):
 
     session = requests.Session()  # Use a session to maintain cookies and headers
     response = session.get(BRIGHTCOVE_API(video_id), headers=BRIGHTCOVE_HEADERS).json()
-    
+
+    # Collect subtitle tracks from the Brightcove response (not in the MPD/m3u8).
+    subtitles = collect_subtitles(response)
+
     download_command = None
-    
+
     if 'sources' in response:
         sources = response['sources']
         source = next((src for src in sources if 'key_systems' in src and 'com.widevine.alpha' in src['key_systems']), None)
@@ -322,49 +343,70 @@ def get_download_command(video_url, downloads_path, wvd_device_path):
                 print(f"{bcolors.LIGHTBLUE}PSSH: {bcolors.ENDC}{pssh}")
                 for key in keys:
                     print(f"{bcolors.GREEN}KEYS: {bcolors.ENDC}--key {key}")
+                if subtitles:
+                    print(f"{bcolors.OKCYAN}Subtitles to embed: {bcolors.ENDC}{describe(subtitles)}")
+                else:
+                    print(f"{bcolors.WARNING}No subtitles available for this title.{bcolors.ENDC}")
                 print(f"{bcolors.YELLOW}DOWNLOAD COMMAND:{bcolors.ENDC}")
-                
+
                 # Build safe base filename
                 base_name = series_name.title().replace('-', '.').replace(' ', '.').replace('_', '.').replace('/', '.').replace(':', '.')
                 if clip_title:
-                    formatted_file_name = f"{base_name}.{clip_title}.{season}{episode}.{max_height}p.9NOW.WEB-DL.AAC2.0.H.264"
+                    formatted_file_name = sanitize_filename(f"{base_name}.{clip_title}.{season}{episode}.{max_height}p.9NOW.WEB-DL.AAC2.0.H.264")
                 else:
-                    formatted_file_name = f"{base_name}.{season}{episode}.{max_height}p.9NOW.WEB-DL.AAC2.0.H.264"
+                    formatted_file_name = sanitize_filename(f"{base_name}.{season}{episode}.{max_height}p.9NOW.WEB-DL.AAC2.0.H.264")
 
-                download_command = f"""N_m3u8DL-RE "{mpd_url}" --select-video best --select-audio best --select-subtitle all -mt -M format=mkv --save-dir "{downloads_path}" --save-name "{formatted_file_name}" --key """ + ' --key '.join(keys)
+                # Subtitles are not in the MPD; handled separately via embed_subtitles.
+                download_command = f"""N_m3u8DL-RE "{mpd_url}" --select-video best --select-audio best -mt -M format=mkv --save-dir "{downloads_path}" --save-name "{formatted_file_name}" --key """ + ' --key '.join(
+                    keys)
                 print(download_command)
         else:
-            # Handling for unencrypted videos with m3u8
-            unencrypted_source = next((src for src in sources if 'src' in src and 'master.m3u8' in src['src']), None)
+            # Handling for unencrypted videos (dynamic delivery / Boltdns HLS).
+            # Boltdns URLs don't contain 'master.m3u8', so select by MIME type.
+            # Prefer HLS v5 (https) > v4 > v3, falling back to any HLS source.
+            hls_sources = [
+                src for src in sources
+                if (src.get("type") or "").lower() == "application/x-mpegurl"
+                   and src.get("src", "").startswith("https")
+            ]
+            # Sort so higher HLS version numbers come first (v5 > v4 > v3).
+            hls_sources.sort(key=lambda s: s.get("src", ""), reverse=True)
+            unencrypted_source = hls_sources[0] if hls_sources else None
             if unencrypted_source:
                 m3u8_url = unencrypted_source['src']
                 max_height = get_max_height_m3u8(m3u8_url)
                 # Print the download command for unencrypted videos
                 print(f"{bcolors.LIGHTBLUE}M3U8 URL: {bcolors.ENDC}{m3u8_url}")
+                if subtitles:
+                    print(f"{bcolors.OKCYAN}Subtitles to embed: {bcolors.ENDC}{describe(subtitles)}")
+                else:
+                    print(f"{bcolors.WARNING}No subtitles available for this title.{bcolors.ENDC}")
                 print(f"{bcolors.YELLOW}DOWNLOAD COMMAND:{bcolors.ENDC}")
 
                 # Build safe base filename
                 base_name = series_name.title().replace('-', '.').replace(' ', '.').replace('_', '.').replace('/', '.').replace(':', '.')
                 if clip_title:
-                    formatted_file_name = f"{base_name}.{clip_title}.{season}{episode}.{max_height}p.9NOW.WEB-DL.AAC2.0.H.264"
+                    formatted_file_name = sanitize_filename(f"{base_name}.{clip_title}.{season}{episode}.{max_height}p.9NOW.WEB-DL.AAC2.0.H.264")
                 else:
-                    formatted_file_name = f"{base_name}.{season}{episode}.{max_height}p.9NOW.WEB-DL.AAC2.0.H.264"
+                    formatted_file_name = sanitize_filename(f"{base_name}.{season}{episode}.{max_height}p.9NOW.WEB-DL.AAC2.0.H.264")
 
-                download_command = f"""N_m3u8DL-RE "{m3u8_url}" --select-video best --select-audio best --select-subtitle all -mt -M format=mkv --save-dir "{downloads_path}" --save-name "{formatted_file_name}" """
+                # Subtitles come from the Brightcove text_tracks response, not the
+                # m3u8 manifest; handled separately via embed_subtitles below.
+                download_command = f"""N_m3u8DL-RE "{m3u8_url}" --select-video best --select-audio best -mt -M format=mkv --save-dir "{downloads_path}" --save-name "{formatted_file_name}" """
                 print(download_command)
             else:
                 print("No suitable source found for unencrypted video")
     else:
         print("No 'sources' found in the response")
-    
+
     if download_command:
         user_input = input("Do you wish to download? Y or N: ").strip().lower()
         if user_input == 'y':
             subprocess.run(download_command, shell=True)
+            if subtitles:
+                embed_subtitles(downloads_path, formatted_file_name, subtitles)
 
 
 # Main execution flow
 def main(video_url, downloads_path, wvd_device_path):
     get_download_command(video_url, downloads_path, wvd_device_path)
-
-

--- a/services/abciview/abc.py
+++ b/services/abciview/abc.py
@@ -1,10 +1,15 @@
 import requests
 import re
+import os
 import base64
 import binascii
 import subprocess
 from xml.etree import ElementTree as ET
 from pywidevine import Cdm, Device, PSSH
+
+from helpers.colors import bcolors
+from helpers.subtitles import sanitize_filename, describe, embed_subtitles
+
 
 #   Ozivine: ABC iView Video Downloader
 #   Author: billybanana
@@ -20,18 +25,10 @@ from pywidevine import Cdm, Device, PSSH
 #   4. Print Download Information: Outputs the MPD URL, license URL, PSSH, and decryption keys required for downloading and decrypting the video content.
 #   5. Note: this script functions for encrypted video files only (ABC iView files are all currently encrypted).
 
-# Define color formatting
-class bcolors:
-    LIGHTBLUE = '\033[94m'
-    RED = '\033[91m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    ENDC = '\033[0m'
-    ORANGE = '\033[38;5;208m'
-
 def get_video_id(url):
     match = re.search(r'video/([A-Z0-9]+)', url)
     return match.group(1) if match else None
+
 
 def get_jwt_token(client_id, jwt_url):
     headers = {
@@ -42,6 +39,7 @@ def get_jwt_token(client_id, jwt_url):
         return response.json().get("token")
     else:
         return None
+
 
 def get_license_data(video_id, drm_url, jwt_token):
     headers = {
@@ -58,6 +56,7 @@ def get_license_data(video_id, drm_url, jwt_token):
             return None, None
     else:
         return None, None
+
 
 # Function to get 1080p MPD URL
 def get_mpd_url(video_id):
@@ -76,6 +75,7 @@ def get_mpd_url(video_id):
     else:
         return None
 
+
 # Function to get PSSH from MPD URL
 def extract_pssh(mpd_url):
     response = requests.get(mpd_url)
@@ -88,6 +88,7 @@ def extract_pssh(mpd_url):
                 return pssh
     return None
 
+
 # Function to get the show information for file name formatting
 def get_show_info(video_id):
     show_info_url = f'https://api.iview.abc.net.au/v3/video/{video_id}'
@@ -97,7 +98,7 @@ def get_show_info(video_id):
         show_title = data.get("showTitle", "UnknownShow").replace(" ", ".")
         title = data.get("title", "")
         status_title = data.get("status", {}).get("title", "")
-        
+
         if status_title == "MOVIE":
             formatted_title = f"{show_title}.1080p.ABCiView.WEB-DL.AAC2.0.H.264"
         else:
@@ -108,8 +109,39 @@ def get_show_info(video_id):
                 formatted_title = f"{show_title}.S{season}E{episode}.1080p.ABCiView.WEB-DL.AAC2.0.H.264"
             else:
                 formatted_title = f"{show_title}.{title.replace(' ', '.')}.1080p.ABCiView.WEB-DL.AAC2.0.H.264"
-        return formatted_title
+        return sanitize_filename(formatted_title)
     return "video"
+
+
+# Function to collect the English caption sidecar (WebVTT).
+# ABC iView does not put captions in the MPD; the programme's playlist entry
+# exposes them as captions["src-vtt"]. (preroll/rating entries have no captions.)
+def collect_subtitles(video_id):
+    api_url = f'https://api.iview.abc.net.au/v3/video/{video_id}'
+    try:
+        response = requests.get(api_url)
+        response.raise_for_status()
+    except requests.RequestException:
+        return []
+
+    playlist = response.json().get("_embedded", {}).get("playlist", [])
+    program = next((p for p in playlist if p.get("type") == "program"), None)
+    if not program:
+        return []
+
+    captions = program.get("captions") or {}
+    url = captions.get("src-vtt")
+    if not url or str(captions.get("live", "0")) == "1":
+        return []
+
+    return [{
+        "url": url,
+        "lang": "en",
+        "name": "English",
+        "default": True,
+        "forced": False,
+    }]
+
 
 # Function to get keys using PSSH and license URL
 def get_license(pssh, video_id, client_id, jwt_url, drm_url, wvd_device_path):
@@ -156,11 +188,13 @@ def get_license(pssh, video_id, client_id, jwt_url, drm_url, wvd_device_path):
     else:
         return None
 
+
 def format_keys(keys):
     formatted_keys = []
     for key in keys:
         formatted_keys.append(f"{key.kid.hex}:{key.key.hex()}")
     return formatted_keys
+
 
 # Main execution flow
 def main(video_url, downloads_path, wvd_device_path):
@@ -179,21 +213,31 @@ def main(video_url, downloads_path, wvd_device_path):
                     formatted_keys = format_keys(license_keys)
                     # Get formatted file name
                     formatted_file_name = get_show_info(video_id)
-                    
+                    # Get the English caption sidecar (not present in the MPD)
+                    captions = collect_subtitles(video_id)
+
                     # Print the requested information
                     print(f"{bcolors.LIGHTBLUE}MPD URL: {bcolors.ENDC}{mpd_url}")
                     print(f"{bcolors.RED}License URL: {bcolors.ENDC}https://wv-keyos.licensekeyserver.com/")
                     print(f"{bcolors.LIGHTBLUE}PSSH: {bcolors.ENDC}{pssh}")
                     for key in formatted_keys:
                         print(f"{bcolors.GREEN}KEYS: {bcolors.ENDC}--key {key}")
+                    if captions:
+                        print(f"{bcolors.LIGHTBLUE}Subtitles to embed: {bcolors.ENDC}{describe(captions)}")
+                    else:
+                        print(f"{bcolors.YELLOW}No subtitles available for this title.{bcolors.ENDC}")
                     print(f"{bcolors.YELLOW}DOWNLOAD COMMAND:{bcolors.ENDC}")
-                    download_command = f"""N_m3u8DL-RE "{mpd_url}" --select-video res=1080 --select-audio all --select-subtitle all -mt -M format=mkv --save-dir "{downloads_path}" --save-name "{formatted_file_name}" --key """ + ' --key '.join(formatted_keys)
+                    # Subtitles are handled separately (downloaded + muxed below); ABC
+                    # does not put them in the MPD, so no --select-subtitle flag here.
+                    download_command = f"""N_m3u8DL-RE "{mpd_url}" --select-video res=1080 --select-audio all -mt -M format=mkv --save-dir "{downloads_path}" --save-name "{formatted_file_name}" --key """ + ' --key '.join(
+                        formatted_keys)
                     print(download_command)
-                    
-                    if download_command:
-                        user_input = input("Do you wish to download? Y or N: ").strip().lower()
-                        if user_input == 'y':
-                            subprocess.run(download_command, shell=True)
+
+                    user_input = input("Do you wish to download? Y or N: ").strip().lower()
+                    if user_input == 'y':
+                        subprocess.run(download_command, shell=True)
+                        if captions:
+                            embed_subtitles(downloads_path, formatted_file_name, captions)
                 else:
                     print("Failed to get license keys")
             else:

--- a/services/sbs/sbs.py
+++ b/services/sbs/sbs.py
@@ -7,6 +7,9 @@ from datetime import datetime, timedelta, timezone
 import requests
 import yaml
 
+from helpers.colors import bcolors
+from helpers.subtitles import sanitize_filename, describe, embed_subtitles
+
 #   Ozivine: SBS On Demand Video Downloader
 #   Author: billybanana
 #   Usage: enter the series/season/episode URL to retrieve the m3u8 Manifest.
@@ -26,6 +29,10 @@ SBS_PLAYBACK_URL = "https://playback.pr.sbsod.com/stream/{video_id}"
 CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "config.yaml")
 CONFIG_PATH = os.path.abspath(CONFIG_PATH)
 
+# Subtitle behaviour: True downloads only English tracks (English / English CC),
+# False downloads every subtitle track SBS offers (Arabic, Korean, Vietnamese, etc).
+ENGLISH_ONLY = True
+
 
 def load_config():
     if not os.path.exists(CONFIG_PATH):
@@ -39,20 +46,6 @@ def save_config(config):
     with open(CONFIG_PATH, "w", encoding="utf-8") as f:
         yaml.safe_dump(config, f, sort_keys=False, allow_unicode=True)
 
-# ANSI escape codes for colors
-class bcolors:
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    LIGHTBLUE = '\033[94m'
-    RED = '\033[91m'
-    YELLOW = '\033[93m'
-    GREEN = '\033[92m'
-    ORANGE = '\033[38;5;208m'
-
 
 # Check for cached token
 def ensure_sbs_cache(config):
@@ -61,6 +54,7 @@ def ensure_sbs_cache(config):
     config["sbs"].setdefault("cache", {})
     config["sbs"]["cache"].setdefault("login", {})
     return config
+
 
 # Obtain login credentials from config
 def parse_sbs_credentials(credentials):
@@ -89,6 +83,7 @@ def parse_iso_datetime(value):
     except Exception:
         return None
 
+
 # Define token expiry
 def jwt_expiry_utc(token):
     try:
@@ -106,6 +101,7 @@ def jwt_expiry_utc(token):
         return datetime.fromtimestamp(exp, tz=timezone.utc)
     except Exception:
         return None
+
 
 # Check if token is valid
 def token_is_valid(token, expiry, buffer_minutes=5):
@@ -126,6 +122,7 @@ def mask_value(value):
     if len(value) <= 20:
         return value
     return f"{value[:10]}...{value[-10:]}"
+
 
 # Login request
 def sbs_login(username, password):
@@ -169,7 +166,8 @@ def sbs_login(username, password):
         "expiry": expiry_dt.isoformat() if expiry_dt else "",
     }
 
-# Function to retrieve access toekn
+
+# Function to retrieve access token
 def get_sbs_access_token(config, credentials):
     config = ensure_sbs_cache(config)
     cache = config["sbs"]["cache"]["login"]
@@ -195,10 +193,12 @@ def get_sbs_access_token(config, credentials):
     print(f"{bcolors.OKGREEN}✅ Token cache updated{bcolors.ENDC}")
     return login_data["token"]
 
+
 # Function to extract video ID from URL
 def extract_video_id(video_url):
     match = re.search(r"/(\d+)", video_url)
     return match.group(1) if match else None
+
 
 # Function to get show information from playback catalogue
 def get_playback_data(video_id, access_token):
@@ -240,12 +240,41 @@ def get_playback_data(video_id, access_token):
     except Exception as e:
         raise RuntimeError(f"Playback endpoint did not return valid JSON: {e}")
 
-# Function to get manifest URL
-def find_hls_url(playback_data):
+
+# Function to get the HLS stream provider (carries both the manifest URL and the
+# subtitle track list).
+def find_hls_provider(playback_data):
     for provider in playback_data.get("streamProviders", []):
         if provider.get("type") == "HLS" and provider.get("url"):
-            return provider["url"]
+            return provider
     return None
+
+
+# Function to collect the wanted subtitle tracks from the playback data.
+# SBS does not put subtitles in the HLS manifest; it returns them as a "textTracks"
+# list on the HLS stream provider. Each row looks like:
+#   {"name": "English (CC)", "type": "CAPTION"/"SUBTITLE", "url": "...VTT",
+#    "lang": "en", "format": "WebVTT", "attributes": ["AUTOSELECT=YES", "DEFAULT=YES"]}
+def collect_subtitles(provider, english_only=True):
+    subs = []
+    for row in provider.get("textTracks", []) or []:
+        url = row.get("url")
+        lang = (row.get("lang") or "und").strip()
+        if not url:
+            continue
+        if english_only and not lang.lower().startswith("en"):
+            continue
+        # Attributes are HLS-style KEY=VALUE strings, e.g. "DEFAULT=YES".
+        attribs = [str(a).upper() for a in row.get("attributes", [])]
+        subs.append({
+            "url": url,
+            "lang": lang,
+            "name": (row.get("name") or "").strip(),
+            "default": "DEFAULT=YES" in attribs,
+            "forced": "FORCED=YES" in attribs,
+        })
+    return subs
+
 
 # Function to get max resolution from manifest
 def get_max_height_m3u8(url_m3u8):
@@ -265,6 +294,7 @@ def get_max_height_m3u8(url_m3u8):
         print(f"Error fetching max height from m3u8: {e}")
         return 0
 
+
 # Function to build the video file name
 def build_filename(playback_data, video_height):
     entity_type = playback_data.get("entityType", "")
@@ -276,52 +306,68 @@ def build_filename(playback_data, video_height):
     resolution_tag = f"{video_height or 720}p"
 
     if entity_type == "MOVIE" or not series_title:
-        return f"{title}.{resolution_tag}.SBS.WEB-DL.AAC2.0.H.264"
+        name = f"{title}.{resolution_tag}.SBS.WEB-DL.AAC2.0.H.264"
+    else:
+        name = f"{series_title}.S{season_number}E{episode_number}.{title}.{resolution_tag}.SBS.WEB-DL.AAC2.0.H.264"
 
-    return f"{series_title}.S{season_number}E{episode_number}.{title}.{resolution_tag}.SBS.WEB-DL.AAC2.0.H.264"
+    return sanitize_filename(name)
+
 
 # Function to extract and print m3u8 URL
 def extract_info(video_url, access_token):
     video_id = extract_video_id(video_url)
     if not video_id:
         print("Failed to extract video ID from the URL.")
-        return None, None
+        return None, None, []
 
     playback_data = get_playback_data(video_id, access_token)
 
-    manifest_url = find_hls_url(playback_data)
-    if not manifest_url:
+    provider = find_hls_provider(playback_data)
+    if not provider:
         print("No HLS manifest URL found in playback data.")
         print(json.dumps(playback_data, indent=2)[:4000])
-        return None, None
+        return None, None, []
+
+    manifest_url = provider["url"]
+    subtitles = collect_subtitles(provider, english_only=ENGLISH_ONLY)
 
     video_height = get_max_height_m3u8(manifest_url)
     formatted_file_name = build_filename(playback_data, video_height)
-    return manifest_url, formatted_file_name
+    return manifest_url, formatted_file_name, subtitles
+
 
 # Function to format and display download command
-def display_download_command(manifest_url, formatted_file_name, downloads_path):
+def display_download_command(manifest_url, formatted_file_name, downloads_path, subtitles):
+    # Subtitles are handled separately (downloaded + muxed below); SBS does not put
+    # them in the HLS manifest, so no --select-subtitle flag is needed here.
     download_command = (
         f'N_m3u8DL-RE "{manifest_url}" '
-        f'--select-video best --select-audio best --select-subtitle all '
+        f'--select-video best --select-audio best '
         f'-mt -M format=mkv --save-dir "{downloads_path}" --save-name "{formatted_file_name}"'
     )
 
     print(f"{bcolors.LIGHTBLUE}M3U8 URL: {bcolors.ENDC}{manifest_url}")
+    if subtitles:
+        print(f"{bcolors.OKCYAN}Subtitles to embed: {bcolors.ENDC}{describe(subtitles)}")
+    else:
+        print(f"{bcolors.WARNING}No subtitles available for this title.{bcolors.ENDC}")
     print(f"{bcolors.YELLOW}DOWNLOAD COMMAND: {bcolors.ENDC}")
     print(download_command)
 
     user_input = input("Do you wish to download? Y or N: ").strip().lower()
     if user_input == "y":
         subprocess.run(download_command, shell=True)
+        if subtitles:
+            embed_subtitles(downloads_path, formatted_file_name, subtitles)
+
 
 # Main function
 def main(video_url, downloads_path, credentials):
     config = load_config()
     access_token = get_sbs_access_token(config, credentials)
 
-    manifest_url, formatted_file_name = extract_info(video_url, access_token)
+    manifest_url, formatted_file_name, subtitles = extract_info(video_url, access_token)
     if not manifest_url:
         return
 
-    display_download_command(manifest_url, formatted_file_name, downloads_path)
+    display_download_command(manifest_url, formatted_file_name, downloads_path, subtitles)

--- a/services/threenow/threenow.py
+++ b/services/threenow/threenow.py
@@ -7,6 +7,8 @@ from pywidevine.pssh import PSSH
 import subprocess
 from datetime import datetime
 
+from helpers.colors import bcolors
+
 #   Ozivine: ThreeNow Video Downloader
 #   Author: billybanana
 #   Usage: enter the movie/series/season/episode URL to retrieve the MPD, Licence, PSSH and Decryption keys.
@@ -35,23 +37,6 @@ BRIGHTCOVE_HEADERS = {
     "Origin": "https://www.threenow.co.nz",
     "Referer": "https://www.threenow.co.nz/"
 }
-
-# ANSI escape codes for colors
-class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
-    LIGHTBLUE = '\033[94m'
-    RED = '\033[91m'
-    GREEN = '\033[92m'
-    YELLOW = '\033[93m'
-    ORANGE = '\033[38;5;208m'
 
 # Get the Brightcove Video ID from the video URL
 def get_video_info(video_url):

--- a/services/tvnz/tvnz.py
+++ b/services/tvnz/tvnz.py
@@ -17,6 +17,8 @@ from pywidevine.cdm import Cdm
 from pywidevine.device import Device
 from pywidevine.pssh import PSSH
 
+from helpers.colors import bcolors
+
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 #   Ozivine: TVNZ Video Downloader
@@ -73,15 +75,6 @@ CATALOG_PARAMS = {
     "pf": "Regular",
     "allowpg": "true",
 }
-
-class bcolors:
-    OKGREEN = "\033[92m"
-    LIGHTBLUE = "\033[94m"
-    RED = "\033[91m"
-    GREEN = "\033[92m"
-    YELLOW = "\033[93m"
-    FAIL = "\033[91m"
-    ENDC = "\033[0m"
 
 
 def first_name(value):


### PR DESCRIPTION
Subtitles for 7Plus, Threenow &TVNZ+ already work via native N_m3u8DL-RE handling as subtitles are embedded in the manifest - so N_m3u8DL-RE downloads them directly and converts to SRT format (its default handling).

This PR adds subtitle support to ABC, SBS, 9 and 10, where the subtitles are not in the manifest.

Uses a simple general strategy of finding the subtitles (varies per service), then downloads & converts them to SRT (ffmpeg, SRT for maximum compatibility and to match the other services), and finally muxes them in (mkvmerge).

Minors:
Tidy-ups to README.md - use code blocks where appropriate.
Re-factor common colours code to a helper class
